### PR TITLE
Default port to a random number

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -144,9 +144,9 @@ module.exports = class extends Generator {
           type: 'list',
           name: 'portNumber',
           choices: [
+            'Random',
             '43711',
-            'Custom',
-            'Random'
+            'Custom'
           ],
           message: 'Which HTTP port would you like to use?'
         },
@@ -258,9 +258,9 @@ module.exports = class extends Generator {
           type: 'list',
           name: 'portNumber',
           choices: [
+            'Random',
             '43733',
-            'Custom',
-            'Random'
+            'Custom'
           ],
           message: 'Which HTTPS port would you like to use?'
         },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -145,7 +145,7 @@ module.exports = class extends Generator {
           name: 'portNumber',
           choices: [
             'Random',
-            '43711',
+            `${defaults.httpPort}`,
             'Custom'
           ],
           message: 'Which HTTP port would you like to use?'
@@ -171,7 +171,7 @@ module.exports = class extends Generator {
       } else if (response.portNumber === 'Custom') {
         this.httpPort = response.customHttpPort
       } else {
-        this.httpPort = 43711
+        this.httpPort = defaults.httpPort
       }
     })
   }
@@ -259,7 +259,7 @@ module.exports = class extends Generator {
           name: 'portNumber',
           choices: [
             'Random',
-            '43733',
+            `${defaults.https.httpsPort}`,
             'Custom'
           ],
           message: 'Which HTTPS port would you like to use?'
@@ -327,7 +327,7 @@ module.exports = class extends Generator {
         } else if (response.portNumber === 'Custom') {
           this.httpsPort = response.customHttpsPort
         } else {
-          this.httpsPort = 43733
+          this.httpsPort = defaults.https.httpsPort
         }
         this.pfx = response.pfx
         this.keyPath = response.keyPath


### PR DESCRIPTION
This allows the user to choose from three options. Default, Custom, and Random port numbers.  Random ports are restricted from 1000 to 65535 and will not allow port 8888 to be assigned. Also will not allow HTTP and HTTPS ports to be the same. (Closes #119)