### PR TITLE
Fixed Options for separateProcess

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -37,7 +37,10 @@
         "requestHeader": "Partial",
         "modelValue": "_disableValidator"
       },
-      "separateProcess": false,
+      "separateProcess": {
+        "enable": false,
+        "autoKiller": false
+      },
       "suppressWarnings": false
     },
     "multipart": {


### PR DESCRIPTION
Apps were being generated with an outdated declaration of `separateProcess`. 
It has been updated to meet our current needs as `separateProcess` has been turned into an object with properties, instead of just a boolean.