### PR TITLE
Updating package.json files

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -6,7 +6,6 @@
   "homepage": "",
   "license": "",
   "main": "app.js",
-  "readmeFilename": "",
   "engines": {
     "node": ">=8.0.0"
   },
@@ -133,7 +132,8 @@
   },
   "private": true,
   "repository": {
-    "private-repo": "git+ssh://somewhere:port/folder/on/server"
+    "type": "git",
+    "url": "https://somewhere.url/user/repo.git"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "homepage": "https://github.com/rooseveltframework/generator-roosevelt",
   "license": "CC-BY-4.0",
   "main": "generators/app/index.js",
-  "readmeFilename": "README.md",
   "engines": {
     "node": ">=10.0.0"
   },


### PR DESCRIPTION
In the template package.json for the generator, it was using the repository.private-repo convention which is not used anymore and I converted it to use the type and url fields instead. As well, I see the readmeFilename field as redundant given most projects save the readme at README.md. I also removed readmeFilename in the root package.json file as well.