### PR TITLE
Fix node-sass dependency

### DIFF
--- a/generators/app/templates/defaults.json
+++ b/generators/app/templates/defaults.json
@@ -29,11 +29,11 @@
   },
   "Sass": {
     "dependencies": {
-      "node-sass": "~4.14.0"
+      "sass": "~1.39.0"
     },
     "config": {
       "enable": true,
-      "module": "node-sass",
+      "module": "sass",
       "options": {}
     },
     "scripts": {

--- a/test/unit/prompts.js
+++ b/test/unit/prompts.js
@@ -203,7 +203,7 @@ describe('Generator Prompts', function () {
           assert.JSONFileContent('rooseveltConfig.json', {
             css: {
               compiler: {
-                module: 'node-sass'
+                module: 'sass'
               }
             }
           })


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #403 

Roosevelt has already been upgraded to dart-sass, so fixing the node-sass dependency in the generator was fairly straightforward. I've tested locally and there is no longer an issue with the css preprocessor crashing when SASS is selected. All npm t tests pass as well.

<img width="819" alt="Screen Shot 2021-12-10 at 10 32 11 AM" src="https://user-images.githubusercontent.com/84106309/145590357-2cf6ea40-41b1-4949-87ed-0d879e40614f.png">

