### PR TITLE
0.19.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Next version
 
-- Various fixes related to css preprocessor linting scripts.
-- Removed support for stylus css preprocessor for now.
-- Fixed compatibility with mkroosevelt in node v17+.
+- Put your changes here...
+
+## 0.19.10
+
+- Various fixes related to CSS preprocessor linting scripts.
+- Removed support for stylus CSS preprocessor for now because it was broken and too difficult to fix in a short turnaround.
+- Fixed compatibility with `mkroosevelt` in node v17+.
 - Removed `install-deps` flag, as newer versions of yeoman won't allow this to work in subdirectories.
 - Added `certs` directory to generated .gitignore.
 - Updated dependency versions for generated apps.
+- Remove obsolete `node-forge` and `yeoman-assert` dependencies.
 - Various dependencies bumped.
 
 ## 0.19.9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Before opening a pull request
 
-- Update dependencies in `package.json`, `generators/app/templates/defaults.json`, and `generators/app/templates/_package.json`.
+- Update dependencies in `package.json`, `generators/app/templates/defaults.json`, and `generators/app/templates/package.json.ejs`.
 - Be sure all tests pass: `npm t`.
 - Ensure 100% code coverage and write new tests if necessary: `npm run coverage`.
 - Add your changes to `CHANGELOG.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generator-roosevelt",
-  "version": "0.19.9",
+  "version": "0.19.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "generator-roosevelt",
-      "version": "0.19.9",
+      "version": "0.19.10",
       "license": "CC-BY-4.0",
       "dependencies": {
         "gulp-beautify": "~3.0.0",
@@ -21,7 +21,7 @@
         "eslint": "~8.19.0",
         "eslint-plugin-mocha": "~10.0.5",
         "mocha": "~10.0.0",
-        "roosevelt": "~0.19.13",
+        "roosevelt": "~0.19.14",
         "standard": "~17.0.0",
         "yeoman-environment": "~3.9.1",
         "yeoman-test": "~6.3.0"
@@ -9820,9 +9820,9 @@
       }
     },
     "node_modules/roosevelt": {
-      "version": "0.19.13",
-      "resolved": "https://registry.npmjs.org/roosevelt/-/roosevelt-0.19.13.tgz",
-      "integrity": "sha512-ZW9nJgc2R9ut4a41E3j1J1kt4GiI7olMyA5jPcHISm6SmD/I4iCrPKHzF3iQOscxpeVGh7IP1+L5GpfpsenBIQ==",
+      "version": "0.19.14",
+      "resolved": "https://registry.npmjs.org/roosevelt/-/roosevelt-0.19.14.tgz",
+      "integrity": "sha512-g1Sh6GiLCo1NIlrGGhoOSmgUKsSwD08NtfnWDSEavzAQRyYdp4f2t0KIZ5wZwoTrOHjhiSelVtjeCVA13mclAg==",
       "dev": true,
       "dependencies": {
         "@colors/colors": "~1.5.0",
@@ -20067,9 +20067,9 @@
       }
     },
     "roosevelt": {
-      "version": "0.19.13",
-      "resolved": "https://registry.npmjs.org/roosevelt/-/roosevelt-0.19.13.tgz",
-      "integrity": "sha512-ZW9nJgc2R9ut4a41E3j1J1kt4GiI7olMyA5jPcHISm6SmD/I4iCrPKHzF3iQOscxpeVGh7IP1+L5GpfpsenBIQ==",
+      "version": "0.19.14",
+      "resolved": "https://registry.npmjs.org/roosevelt/-/roosevelt-0.19.14.tgz",
+      "integrity": "sha512-g1Sh6GiLCo1NIlrGGhoOSmgUKsSwD08NtfnWDSEavzAQRyYdp4f2t0KIZ5wZwoTrOHjhiSelVtjeCVA13mclAg==",
       "dev": true,
       "requires": {
         "@colors/colors": "~1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/generator-roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.19.9",
+  "version": "0.19.10",
   "files": [
     "generators"
   ],


### PR DESCRIPTION
- Various fixes related to CSS preprocessor linting scripts.
- Removed support for stylus CSS preprocessor for now because it was broken and too difficult to fix in a short turnaround.
- Fixed compatibility with `mkroosevelt` in node v17+.
- Removed `install-deps` flag, as newer versions of yeoman won't allow this to work in subdirectories.
- Added `certs` directory to generated .gitignore.
- Updated dependency versions for generated apps.
- Remove obsolete `node-forge` and `yeoman-assert` dependencies.
- Various dependencies bumped.