### PR TITLE
Running `npx mkroosevelt` no longer returns undefined.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -794,7 +794,7 @@ module.exports = class extends Generator {
       if (!this.options['skip-closing-message']) {
         this.log(`\nYour app ${this.appName} has been generated.\n`)
         this.log('To run the app:')
-        this.log('- Change to your app directory:  cd ' + this.dirname)
+        this.log('- Change to your app directory:  cd ' + this.appName)
         this.log('- Install dependencies:          npm i')
         this.log('- To run in development mode:    npm run d')
         this.log('- To run in production mode:     npm run p')


### PR DESCRIPTION
 Originally when running `npx mkroosevelt`, it would return: `Change to your app directory:  cd undefined`.  Changed this.dirname to this.appName  in the index.js file and now the text renders: `Change to your app directory:  cd Your-App-Name`

This fixes issue 160 for mkroosevelt. 
Issue Link: https://github.com/rooseveltframework/mkroosevelt/issues/160